### PR TITLE
Improvement: output request count

### DIFF
--- a/lib/core.rb
+++ b/lib/core.rb
@@ -59,13 +59,14 @@ def hydrate_stats(stats, puma_state, state_file_path)
 end
 
 def format_stats(stats)
-  master_line = "#{stats.pid} (#{stats.state_file_path}) Uptime: #{seconds_to_human(stats.uptime)} "
-  master_line += "| Phase: #{stats.phase} " if stats.phase
+  master_line = "#{stats.pid} (#{stats.state_file_path}) Uptime: #{seconds_to_human(stats.uptime)}"
+  master_line += " | Phase: #{stats.phase}" if stats.phase
 
   if stats.booting?
     master_line += warn("booting")
   else
-    master_line += "| Load: #{color(75, 50, stats.load, asciiThreadLoad(stats.running_threads, stats.max_threads))}"
+    master_line += " | Load: #{color(75, 50, stats.load, asciiThreadLoad(stats.running_threads, stats.max_threads))}"
+    master_line += " | Req: #{stats.requests_count}" if stats.requests_count
   end
 
   output = [master_line] + stats.workers.map do |wstats|
@@ -77,8 +78,8 @@ def format_stats(stats)
       worker_line += " #{error("killed")}"
     else
       worker_line += " | Load: #{color(75, 50, wstats.load, asciiThreadLoad(wstats.running_threads, wstats.max_threads))}"
+      worker_line += " | Phase: #{error(wstats.phase)}" if wstats.phase != stats.phase
       worker_line += " | Req: #{wstats.requests_count}" if wstats.requests_count
-      worker_line += " Phase: #{error(wstats.phase)}" if wstats.phase != stats.phase
       worker_line += " Queue: #{error(wstats.backlog.to_s)}" if wstats.backlog > 0
       worker_line += " Last checkin: #{error(wstats.last_checkin)}" if wstats.last_checkin >= 10
     end

--- a/lib/core.rb
+++ b/lib/core.rb
@@ -63,7 +63,7 @@ def format_stats(stats)
   master_line += " | Phase: #{stats.phase}" if stats.phase
 
   if stats.booting?
-    master_line += warn("booting")
+    master_line += " #{warn("booting")}"
   else
     master_line += " | Load: #{color(75, 50, stats.load, asciiThreadLoad(stats.running_threads, stats.max_threads))}"
     master_line += " | Req: #{stats.requests_count}" if stats.requests_count

--- a/lib/core.rb
+++ b/lib/core.rb
@@ -62,7 +62,7 @@ def format_stats(stats)
       worker_line += " #{error("killed")}"
     else
       worker_line += " | Load: #{color(75, 50, wstats.load, asciiThreadLoad(wstats.running_threads, wstats.max_threads))}"
-      worker_line += " | Rqs: #{color(10000, 8000, wstats.requests_count)}" if wstats.requests_count
+      worker_line += " | Req: #{wstats.requests_count}" if wstats.requests_count
       worker_line += " Phase: #{error(wstats.phase)}" if wstats.phase != stats.phase
       worker_line += " Queue: #{error(wstats.backlog.to_s)}" if wstats.backlog > 0
       worker_line += " Last checkin: #{error(wstats.last_checkin)}" if wstats.last_checkin >= 10

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -17,7 +17,8 @@ def colorize(str, color_name)
   str.to_s.colorize(color_name)
 end
 
-def color(critical, warn, value, str)
+def color(critical, warn, value, str = nil)
+  str = value unless str
   color_level = if value >= critical
             :red
           elsif value < critical && value >= warn

--- a/lib/stats.rb
+++ b/lib/stats.rb
@@ -9,6 +9,14 @@ class Stats
       @wstats['pid']
     end
 
+    def killed=(killed)
+      @wstats['killed'] = killed
+    end
+
+    def killed?
+      @wstats['killed']
+    end
+
     def mem=(mem)
       @wstats['mem'] = mem
     end
@@ -23,6 +31,10 @@ class Stats
 
     def pcpu
       @wstats['pcpu']
+    end
+
+    def booting?
+      @wstats['last_status'] && @wstats['last_status'].empty?
     end
 
     def running
@@ -53,6 +65,10 @@ class Stats
     def uptime
       return 0 unless @wstats.key?('started_at')
       (Time.now - Time.parse(@wstats['started_at'])).to_i
+    end
+
+    def requests_count
+      @wstats.dig('last_status', 'requests_count') || @wstats['requests_count'] || 0
     end
 
     def backlog
@@ -93,6 +109,10 @@ class Stats
   def uptime
     return 0 unless @stats.key?('started_at')
     (Time.now - Time.parse(@stats['started_at'])).to_i
+  end
+
+  def booting?
+    workers.all?(&:booting?)
   end
 
   def total_threads

--- a/lib/stats.rb
+++ b/lib/stats.rb
@@ -129,7 +129,7 @@ class Stats
 
   def requests_count
     workers_with_requests_count = workers.select(&:requests_count)
-    return unless workers_with_requests_count.any?
+    return if workers_with_requests_count.none?
     workers_with_requests_count.reduce(0) { |total, wstats| total + wstats.requests_count }
   end
 

--- a/lib/stats.rb
+++ b/lib/stats.rb
@@ -68,7 +68,7 @@ class Stats
     end
 
     def requests_count
-      @wstats.dig('last_status', 'requests_count') || @wstats['requests_count'] || 0
+      @wstats.dig('last_status', 'requests_count') || @wstats['requests_count']
     end
 
     def backlog
@@ -125,6 +125,12 @@ class Stats
 
   def max_threads
     workers.reduce(0) { |total, wstats| total + wstats.max_threads }
+  end
+
+  def requests_count
+    workers_with_requests_count = workers.select(&:requests_count)
+    return unless workers_with_requests_count.any?
+    workers_with_requests_count.reduce(0) { |total, wstats| total + wstats.requests_count }
   end
 
   def running

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -81,8 +81,8 @@ describe 'Core' do
       ClimateControl.modify NO_COLOR: '1' do
         expect(format_stats(Stats.new(stats))).to eq(
 %Q{12328 (../testpuma/tmp/puma.state) Uptime:  0m 0s | Phase: 1 | Load: 0[░░░░░░░░░░░░░░░░]16
- └ 12362 CPU:   0.0% Mem:   64 MB Uptime:  0m 0s | Load: 0[░░░░]4 Phase: 0
- └ 12366 CPU:   0.0% Mem:   64 MB Uptime:  0m 0s | Load: 0[░░░░]4 Phase: 0
+ └ 12362 CPU:   0.0% Mem:   64 MB Uptime:  0m 0s | Load: 0[░░░░]4 | Phase: 0
+ └ 12366 CPU:   0.0% Mem:   64 MB Uptime:  0m 0s | Load: 0[░░░░]4 | Phase: 0
  └ 12370 CPU:   0.0% Mem:   64 MB Uptime:  0m 0s | Load: 0[░░░░]4
  └ 12372 CPU:   0.0% Mem:   64 MB Uptime:  0m 0s | Load: 0[░░░░]4})
       end

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -137,6 +137,19 @@ describe 'Core' do
       end
     end
 
+    it 'show the number of request when present in clustered mode' do
+      stats = {"started_at"=>"2019-07-14T10:49:24Z", "workers"=>4, "phase"=>0, "booted_workers"=>4, "old_workers"=>0, "worker_status"=>[{"started_at"=>"2019-07-14T10:49:24Z", "pid"=>12362, "index"=>0, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T13:09:00Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>4, "max_threads"=>4, "requests_count"=>150}, "mem"=>64, "pcpu"=>0.0}, {"started_at"=>"2019-07-14T10:49:24Z", "pid"=>12366, "index"=>1, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T13:09:00Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>4, "max_threads"=>4, "requests_count"=>223}, "mem"=>64, "pcpu"=>0.0}, {"started_at"=>"2019-07-14T10:49:24Z", "pid"=>12370, "index"=>2, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T13:09:00Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>4, "max_threads"=>4, "requests_count"=>450}, "mem"=>64, "pcpu"=>0.0}, {"started_at"=>"2019-07-14T10:49:24Z", "pid"=>12372, "index"=>3, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T13:09:00Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>4, "max_threads"=>4, "requests_count"=>10}, "mem"=>64, "pcpu"=>0.0}], "pid"=>12328, "state_file_path"=>"../testpuma/tmp/puma.state"}
+      
+      ClimateControl.modify NO_COLOR: '1' do
+        expect(format_stats(Stats.new(stats))).to eq(
+%Q{12328 (../testpuma/tmp/puma.state) Uptime:  0m 0s | Phase: 0 | Load: 0[░░░░░░░░░░░░░░░░]16 | Req: 833
+ └ 12362 CPU:   0.0% Mem:   64 MB Uptime:  0m 0s | Load: 0[░░░░]4 | Req: 150
+ └ 12366 CPU:   0.0% Mem:   64 MB Uptime:  0m 0s | Load: 0[░░░░]4 | Req: 223
+ └ 12370 CPU:   0.0% Mem:   64 MB Uptime:  0m 0s | Load: 0[░░░░]4 | Req: 450
+ └ 12372 CPU:   0.0% Mem:   64 MB Uptime:  0m 0s | Load: 0[░░░░]4 | Req: 10})
+      end
+    end
+
     it 'works in single mode' do
       stats = {"started_at"=>"2019-07-14T10:49:24Z", "backlog"=>0, "running"=>4, "pool_capacity"=>4, "max_threads"=>4, "pid"=>21725, "state_file_path"=>"../testpuma/tmp/puma.state", "pcpu"=>10, "mem"=>64}
       
@@ -146,6 +159,15 @@ describe 'Core' do
  └ 21725 CPU:    10% Mem:   64 MB Uptime:  0m 0s | Load: 0[░░░░]4})
       end
     end
-  end
 
+    it 'show the number of request when present in single mode' do
+      stats = {"started_at"=>"2019-07-14T10:49:24Z", "backlog"=>0, "running"=>4, "pool_capacity"=>4, "max_threads"=>4, "pid"=>21725, "state_file_path"=>"../testpuma/tmp/puma.state", "pcpu"=>10, "mem"=>64, "requests_count"=> 150}
+      
+      ClimateControl.modify NO_COLOR: '1' do
+        expect(format_stats(Stats.new(stats))).to eq(
+%Q{21725 (../testpuma/tmp/puma.state) Uptime:  0m 0s | Load: 0[░░░░]4 | Req: 150
+ └ 21725 CPU:    10% Mem:   64 MB Uptime:  0m 0s | Load: 0[░░░░]4 | Req: 150})
+      end
+    end
+  end
 end

--- a/spec/stats_spec.rb
+++ b/spec/stats_spec.rb
@@ -34,6 +34,11 @@ describe Stats do
        expect(stats.booting?).to eq(true)
      end
 
+     it 'gives the number of requests' do
+       stats = Stats.new({"workers"=>4, "phase"=>0, "booted_workers"=>4, "old_workers"=>0, "worker_status"=>[{"pid"=>28909, "index"=>0, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T14:33:54Z", "last_status"=>{"requests_count" => 150}}, {"pid"=>28911, "index"=>1, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T14:33:54Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>0, "max_threads"=>4, "requests_count" => 300}}]})
+       expect(stats.requests_count).to eq(450)
+     end
+
      context 'workers' do
        it 'gives running threads first worker' do
          expect(stats.workers.first.running_threads).to eq(4)
@@ -63,11 +68,17 @@ describe Stats do
          worker = stats.workers.first
          expect(worker.booting?).to eq(true)
        end
+
+       it 'gives the number of requests' do
+         stats = Stats.new({"workers"=>4, "phase"=>0, "booted_workers"=>4, "old_workers"=>0, "worker_status"=>[{"pid"=>28909, "index"=>0, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T14:33:54Z", "last_status"=>{"requests_count" => 150}}, {"pid"=>28911, "index"=>1, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T14:33:54Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>0, "max_threads"=>4, "requests_count" => 300}}]})
+         worker = stats.workers.first
+         expect(worker.requests_count).to eq(150)
+       end
      end
   end
 
   context 'single stats' do
-    let(:stats) { Stats.new({"started_at"=>"2019-07-14T15:07:15Z", "backlog"=>0, "running"=>4, "pool_capacity"=>2, "max_threads"=>4}) }
+    let(:stats) { Stats.new({"started_at"=>"2019-07-14T15:07:15Z", "backlog"=>0, "running"=>4, "pool_capacity"=>2, "max_threads"=>4, "requests_count"=>150}) }
 
      it 'returns uptime 0 for older version of puma' do
        stats = Stats.new({"backlog"=>0, "running"=>4, "pool_capacity"=>2, "max_threads"=>4})
@@ -86,6 +97,10 @@ describe Stats do
        expect(stats.total_threads).to eq(4)
      end
 
+     it 'gives the number of requests' do
+       expect(stats.requests_count).to eq(150)
+     end
+
      context 'workers' do
        it 'gives running threads' do
          expect(stats.workers.first.running_threads).to eq(2)
@@ -93,6 +108,10 @@ describe Stats do
 
        it 'gives total threads' do
          expect(stats.workers.first.total_threads).to eq(4)
+       end
+
+       it 'gives the number of requests' do
+         expect(stats.workers.first.requests_count).to eq(150)
        end
      end
   end


### PR DESCRIPTION
Improve the output

- mark worker as killed / booting
- change order of optional fields
- add request count (this is based on https://github.com/puma/puma/pull/2106)

Demo:
https://youtu.be/iILkbEsDSxc