### PR TITLE
Better: do not hide ENOENT / EISDIR errors. #5

### DIFF
--- a/lib/puma-status.rb
+++ b/lib/puma-status.rb
@@ -17,11 +17,19 @@ def run
     begin
       debug "State file: #{state_file_path}"
       format_stats(get_stats(state_file_path))
-    rescue Errno::ENOENT
-      errors << "#{warn(state_file_path)} doesn't exists"
+    rescue Errno::ENOENT => e
+      if e.message =~ /#{state_file_path}/
+        errors << "#{warn(state_file_path)} doesn't exists"
+      else
+        errors << "#{error(state_file_path)} an unhandled error occured: #{e.inspect}"
+      end
       nil
-    rescue Errno::EISDIR
-      errors << "#{warn(state_file_path)} isn't a state file"
+    rescue Errno::EISDIR => e
+      if e.message =~ /#{state_file_path}/
+        errors << "#{warn(state_file_path)} isn't a state file"
+      else
+        errors << "#{error(state_file_path)} an unhandled error occured: #{e.inspect}"
+      end
       nil
     rescue => e
       errors << "#{error(state_file_path)} an unhandled error occured: #{e.inspect}"


### PR DESCRIPTION
This PR goal is to stop hiding ENOENT / EISDIR errors when they are not related to the provided state file.

This is not a fix for #5 but a first step which would have made the debugging easier