### PR TITLE
Add warning when unix socket is relative. #5

### DIFF
--- a/lib/core.rb
+++ b/lib/core.rb
@@ -9,7 +9,7 @@ def get_stats(state_file_path)
   puma_state = YAML.load_file(state_file_path)
 
   uri = URI.parse(puma_state["control_url"])
-  
+
   address = if uri.scheme =~ /unix/i
               [uri.scheme, '://', uri.host, uri.path].join
             else

--- a/lib/puma-status.rb
+++ b/lib/puma-status.rb
@@ -20,6 +20,8 @@ def run
     rescue Errno::ENOENT => e
       if e.message =~ /#{state_file_path}/
         errors << "#{warn(state_file_path)} doesn't exists"
+      elsif e.message =~ /connect\(2\) for [^\/]/
+        errors << "#{warn("Relative Unix socket")}: the Unix socket of the control app has a relative path. Please, ensure you are running from the same folder has puma."
       else
         errors << "#{error(state_file_path)} an unhandled error occured: #{e.inspect}"
       end

--- a/spec/puma-status_spec.rb
+++ b/spec/puma-status_spec.rb
@@ -72,24 +72,36 @@ describe 'Puma Status' do
       end
     end
 
-    context 'errors not related to state files' do
+    context 'relative unix socket' do
       it 'handles ENOENT errors' do
         allow_any_instance_of(Object).to receive(:get_stats).and_raise(Errno::ENOENT, "connect(2) for tmp/puma.sock")
 
         expect {
           run
         }.to output(%Q{
-./tmp/puma.state an unhandled error occured: #<Errno::ENOENT: No such file or directory - connect(2) for tmp/puma.sock>
+Relative Unix socket: the Unix socket of the control app has a relative path. Please, ensure you are running from the same folder has puma.
 }).to_stdout
       end
+    end
 
-      it 'handles EISDIR errors' do
-        allow_any_instance_of(Object).to receive(:get_stats).and_raise(Errno::EISDIR, "~/Projects/test-puma/tmp")
+    context 'errors not related to state files' do
+      it 'handles ENOENT errors' do
+        allow_any_instance_of(Object).to receive(:get_stats).and_raise(Errno::ENOENT, "DUMMY ERROR")
 
         expect {
           run
         }.to output(%Q{
-./tmp/puma.state an unhandled error occured: #<Errno::EISDIR: Is a directory - ~/Projects/test-puma/tmp>
+./tmp/puma.state an unhandled error occured: #<Errno::ENOENT: No such file or directory - DUMMY ERROR>
+}).to_stdout
+      end
+
+      it 'handles EISDIR errors' do
+        allow_any_instance_of(Object).to receive(:get_stats).and_raise(Errno::EISDIR, "DUMMY ERROR")
+
+        expect {
+          run
+        }.to output(%Q{
+./tmp/puma.state an unhandled error occured: #<Errno::EISDIR: Is a directory - DUMMY ERROR>
 }).to_stdout
       end
     end


### PR DESCRIPTION
To avoid issues with relative unix socket path, this PR adds a warning when puma-status is used with this kink of relative socket path.

We need to do that because puma-status can be run from every where on the system and the puma state file doesn't give the root of relative paths