### PR TITLE
Fix: Coloring of load when min threads != max threads

### DIFF
--- a/lib/stats.rb
+++ b/lib/stats.rb
@@ -40,11 +40,11 @@ class Stats
     def running
       @wstats.dig('last_status', 'running') || @wstats['running'] || 0
     end
-    alias :total_threads :running
 
     def max_threads
       @wstats.dig('last_status', 'max_threads') || @wstats['max_threads'] || 0
     end
+    alias :total_threads :max_threads
 
     def pool_capacity
       @wstats.dig('last_status', 'pool_capacity') || @wstats['pool_capacity'] || 0

--- a/spec/stats_spec.rb
+++ b/spec/stats_spec.rb
@@ -48,12 +48,12 @@ describe Stats do
          expect(stats.workers.first.total_threads).to eq(4)
        end
 
-       it 'gives total threads last worker' do
-         expect(stats.workers.last.total_threads).to eq(4)
-       end
-
        it 'gives running threads last worker' do
          expect(stats.workers.last.running_threads).to eq(1)
+       end
+
+       it 'gives total threads last worker' do
+         expect(stats.workers.last.total_threads).to eq(4)
        end
 
        it 'can mark worker as killed' do

--- a/spec/stats_spec.rb
+++ b/spec/stats_spec.rb
@@ -5,7 +5,7 @@ require './lib/stats'
 describe Stats do
 
   context 'clustered stats' do
-    let(:stats) { Stats.new({"started_at"=>"2019-07-14T14:32:56Z", "workers"=>4, "phase"=>0, "booted_workers"=>4, "old_workers"=>0, "worker_status"=>[{"started_at"=>"2019-07-14T14:32:56Z", "pid"=>28909, "index"=>0, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T14:33:54Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>0, "max_threads"=>4}}, {"started_at"=>"2019-07-14T14:32:56Z", "pid"=>28911, "index"=>1, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T14:33:54Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>0, "max_threads"=>4}}, {"started_at"=>"2019-07-14T14:32:56Z", "pid"=>28917, "index"=>2, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T14:33:54Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>1, "max_threads"=>4}}, {"started_at"=>"2019-07-14T14:32:56Z", "pid"=>28921, "index"=>3, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T14:33:54Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>2, "max_threads"=>4}}]}) }
+    let(:stats) { Stats.new({"started_at"=>"2019-07-14T14:32:56Z", "workers"=>4, "phase"=>0, "booted_workers"=>4, "old_workers"=>0, "worker_status"=>[{"started_at"=>"2019-07-14T14:32:56Z", "pid"=>28909, "index"=>0, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T14:33:54Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>0, "max_threads"=>4}}, {"started_at"=>"2019-07-14T14:32:56Z", "pid"=>28911, "index"=>1, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T14:33:54Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>0, "max_threads"=>4}}, {"started_at"=>"2019-07-14T14:32:56Z", "pid"=>28917, "index"=>2, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T14:33:54Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>1, "max_threads"=>4}}, {"started_at"=>"2019-07-14T14:32:56Z", "pid"=>28921, "index"=>3, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T14:33:54Z", "last_status"=>{"backlog"=>0, "running"=>2, "pool_capacity"=>3, "max_threads"=>4}}]}) }
 
      it 'returns uptime 0 for older version of puma' do
        stats = Stats.new({"workers"=>4, "phase"=>0, "booted_workers"=>4, "old_workers"=>0, "worker_status"=>[{"pid"=>28909, "index"=>0, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T14:33:54Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>0, "max_threads"=>4}}, {"pid"=>28911, "index"=>1, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T14:33:54Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>0, "max_threads"=>4}}, {"pid"=>28917, "index"=>2, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T14:33:54Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>1, "max_threads"=>4}}, {"pid"=>28921, "index"=>3, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T14:33:54Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>2, "max_threads"=>4}}]})
@@ -18,7 +18,7 @@ describe Stats do
      end
 
      it 'gives running threads' do
-       expect(stats.running_threads).to eq(13)
+       expect(stats.running_threads).to eq(12)
      end
 
      it 'gives total threads' do
@@ -48,12 +48,12 @@ describe Stats do
          expect(stats.workers.first.total_threads).to eq(4)
        end
 
-       it 'gives running threads last worker' do
-         expect(stats.workers.last.running_threads).to eq(2)
-       end
-
        it 'gives total threads last worker' do
          expect(stats.workers.last.total_threads).to eq(4)
+       end
+
+       it 'gives running threads last worker' do
+         expect(stats.workers.last.running_threads).to eq(1)
        end
 
        it 'can mark worker as killed' do


### PR DESCRIPTION
Recently I noticed that I did all my tests with `max threads == min threads`

This means on configuration where `max threads != min threads` the coloring could be wrong

For example:

![Screenshot_2021-03-10_22-58-45](https://user-images.githubusercontent.com/1866809/110703581-3ff5aa80-81f4-11eb-9b8e-238e8eb6efe2.png)
![Screenshot_2021-03-10_22-58-56](https://user-images.githubusercontent.com/1866809/110703585-41bf6e00-81f4-11eb-909d-9f505b3f93c3.png)

This is because `running` in puma stats means the number of threads kept alive in the thread pool and not the current number of threads processing a request.

To get this number we have to do `max_threads - pool capacity`

Only the coloring was affected by this confusion, the thead load display was correct
