### PR TITLE
Better: Show number of spawned threads.

### DIFF
--- a/lib/core.rb
+++ b/lib/core.rb
@@ -82,7 +82,7 @@ def format_stats(stats)
   if stats.booting?
     master_line += " #{warn("booting")}"
   else
-    master_line += " | Load: #{color(75, 50, stats.load, asciiThreadLoad(stats.running_threads, stats.max_threads))}"
+    master_line += " | Load: #{color(75, 50, stats.load, asciiThreadLoad(stats.running_threads, stats.spawned_threads, stats.max_threads))}"
     master_line += " | Req: #{stats.requests_count}" if stats.requests_count
   end
 
@@ -94,7 +94,7 @@ def format_stats(stats)
     elsif wstats.killed?
       worker_line += " #{error("killed")}"
     else
-      worker_line += " | Load: #{color(75, 50, wstats.load, asciiThreadLoad(wstats.running_threads, wstats.max_threads))}"
+      worker_line += " | Load: #{color(75, 50, wstats.load, asciiThreadLoad(wstats.running_threads, wstats.spawned_threads, wstats.max_threads))}"
       worker_line += " | Phase: #{error(wstats.phase)}" if wstats.phase != stats.phase
       worker_line += " | Req: #{wstats.requests_count}" if wstats.requests_count
       worker_line += " Queue: #{error(wstats.backlog.to_s)}" if wstats.backlog > 0

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -29,11 +29,16 @@ def color(critical, warn, value, str = nil)
   colorize(str, color_level)
 end
 
-def asciiThreadLoad(idx, total)
+def asciiThreadLoad(running, spawned, total)
   full = "█"
-  empty= "░"
+  half= "░"
+  empty = " "
 
-  "#{idx}[#{full*idx}#{empty*(total-idx)}]#{total}"
+  full_count = running
+  half_count = [spawned - running, 0].max
+  empty_count = total - half_count - full_count
+
+  "#{running}[#{full*full_count}#{half*half_count}#{empty*empty_count}]#{total}"
 end
 
 def seconds_to_human(seconds)

--- a/lib/stats.rb
+++ b/lib/stats.rb
@@ -40,11 +40,12 @@ class Stats
     def running
       @wstats.dig('last_status', 'running') || @wstats['running'] || 0
     end
-    alias :total_threads :running
+    alias :spawned_threads :running
 
     def max_threads
       @wstats.dig('last_status', 'max_threads') || @wstats['max_threads'] || 0
     end
+    alias :total_threads :max_threads
 
     def pool_capacity
       @wstats.dig('last_status', 'pool_capacity') || @wstats['pool_capacity'] || 0
@@ -121,6 +122,10 @@ class Stats
 
   def running_threads
     workers.reduce(0) { |total, wstats| total + wstats.running_threads }
+  end
+
+  def spawned_threads
+    workers.reduce(0) { |total, wstats| total + wstats.spawned_threads }
   end
 
   def max_threads

--- a/lib/stats.rb
+++ b/lib/stats.rb
@@ -40,12 +40,12 @@ class Stats
     def running
       @wstats.dig('last_status', 'running') || @wstats['running'] || 0
     end
+    alias :total_threads :running
     alias :spawned_threads :running
 
     def max_threads
       @wstats.dig('last_status', 'max_threads') || @wstats['max_threads'] || 0
     end
-    alias :total_threads :max_threads
 
     def pool_capacity
       @wstats.dig('last_status', 'pool_capacity') || @wstats['pool_capacity'] || 0

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -137,11 +137,11 @@ describe 'Core' do
       it 'displays the right amount of max threads' do
         ClimateControl.modify NO_COLOR: '1' do
           expect(format_stats(Stats.new(stats))).to eq(
-%Q{12328 (../testpuma/tmp/puma.state) Uptime:  5m23s | Phase: 0 | Load: 0[░░░░░░░░░░░░░░░░]16
- └ 12362 CPU:   0.0% Mem:   64 MB Uptime:  5m23s | Load: 0[░░░░]4
- └ 12366 CPU:   0.0% Mem:   64 MB Uptime:  5m23s | Load: 0[░░░░]4
- └ 12370 CPU:   0.0% Mem:   64 MB Uptime:  5m23s | Load: 0[░░░░]4
- └ 12372 CPU:   0.0% Mem:   64 MB Uptime:  5m23s | Load: 0[░░░░]4})
+%Q{12328 (../testpuma/tmp/puma.state) Uptime:  5m23s | Phase: 0 | Load: 0[░░░░            ]16
+ └ 12362 CPU:   0.0% Mem:   64 MB Uptime:  5m23s | Load: 0[░   ]4
+ └ 12366 CPU:   0.0% Mem:   64 MB Uptime:  5m23s | Load: 0[░   ]4
+ └ 12370 CPU:   0.0% Mem:   64 MB Uptime:  5m23s | Load: 0[░   ]4
+ └ 12372 CPU:   0.0% Mem:   64 MB Uptime:  5m23s | Load: 0[░   ]4})
           end
         end
     end

--- a/spec/helpers_spec.rb
+++ b/spec/helpers_spec.rb
@@ -28,15 +28,19 @@ describe 'Helpers' do
 
   context 'asciiThreadLoad' do
     it 'works when empty' do
-      expect(asciiThreadLoad(0, 0)).to eq('0[]0')
+      expect(asciiThreadLoad(0, 0, 0)).to eq('0[]0')
     end
 
     it 'works with data' do
-      expect(asciiThreadLoad(4, 8)).to eq('4[████░░░░]8')
+      expect(asciiThreadLoad(4, 8, 8)).to eq('4[████░░░░]8')
+    end
+
+    it 'show spawned threads' do
+      expect(asciiThreadLoad(4, 6, 8)).to eq('4[████░░  ]8')
     end
 
     it 'works when full' do
-      expect(asciiThreadLoad(9, 9)).to eq('9[█████████]9')
+      expect(asciiThreadLoad(9, 9, 9)).to eq('9[█████████]9')
     end
   end
 


### PR DESCRIPTION
Following #14 when the `min threads != max threads` we currently have no way of knowing the number of active threads in the thread pool

This is a proposal to show them in a light color:

Below example are with:

```
Max threads = 5
Min threads = 2
```

![Screenshot_2021-03-10_23-09-59](https://user-images.githubusercontent.com/1866809/110705022-12116580-81f6-11eb-8020-4f80c63ae518.png)

(showing 5 (2 +3) because of a previous burst of 5 request and 1 thread will be reaped soon)
![Screenshot_2021-03-10_23-09-33](https://user-images.githubusercontent.com/1866809/110705167-48e77b80-81f6-11eb-8037-3737278bac4d.png)

With one running request (the coloring is wrong and fixed in #14)
![Screenshot_2021-03-10_23-10-14](https://user-images.githubusercontent.com/1866809/110705245-687ea400-81f6-11eb-894e-fa9cdab2617f.png)

```
Max threads = 5
Min threads = 5
```

![Screenshot_2021-03-10_23-15-22](https://user-images.githubusercontent.com/1866809/110705301-7f24fb00-81f6-11eb-9914-4e3a72800724.png)

![Screenshot_2021-03-10_23-15-41](https://user-images.githubusercontent.com/1866809/110705333-8a782680-81f6-11eb-918b-5752e234f66b.png)

