### PR TITLE
Fix: specs running with ruby-head (3.1)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
-    timecop (0.9.1)
+    timecop (0.9.4)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Timecop has been recently updated to 0.9.4 https://github.com/travisjeffery/timecop/blob/master/History.md#v094 to have it compatible with latest ruby head (3.1)