### PR TITLE
Fix shell escape vulnerability

### DIFF
--- a/lib/core.rb
+++ b/lib/core.rb
@@ -51,7 +51,7 @@ CPU_COLUMN = 8
 
 def get_top_stats(pids)
   pids.each_slice(19).inject({}) do |res, pids19|
-    top_result = `top -b -n 1 -p #{pids19.join(',')} | tail -n #{pids19.length}`
+    top_result = `top -b -n 1 -p #{pids19.map(&:to_i).join(',')} | tail -n #{pids19.length}`
     top_result.split("\n").map { |row| r = row.split(' '); [r[PID_COLUMN].to_i, get_memory_from_top(r[MEM_COLUMN]), r[CPU_COLUMN].to_f] }
       .inject(res) { |hash, row| hash[row[0]] = { mem: row[1], pcpu: row[2] }; hash }
     res

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -6,6 +6,11 @@ require './lib/helpers'
 describe 'Core' do
 
   context 'get_top_stats' do
+    it 'prevents shell injections' do
+      get_top_stats(['| echo "shell injection" > /tmp/out.log'])
+      expect(File).not_to exist('/tmp/out.log')
+    end
+
     it 'returns mem and cpu' do
       allow(self).to receive(:`) {
         %Q{12362 ylecuyer  20   0 1144000  65764   8916 S   0,0  1,8   0:05.18 bundle


### PR DESCRIPTION
Pids go into the shell without any quoting, therefore, a MitM can craft HTTP reply from Puma that will execute arbitrary command. Since this utility can be often executed as root, it could be possibly dangerous. However, typically either UNIX socket or HTTPS with SSL verification is used, so the attack surface is probably narrow. Still it is a bug.

I would recommend to avoid spawning shell via Ruby backticks, it would be much safer to use `popen3` where you can pass environment variable `LC_ALL=C` so the replacing decimal separator is not necessary. On top of that, no `tail` is needed you could do this in Ruby code. Finally, avoiding spawning shell will also be faster, I am pretty sure there are many monitoring tools utilizing your code or even the command.

We use this in our project and product, thanks you! :-)

Stay safe. Cheers!