### PR TITLE
CI: Use bundler 2 for ruby-head

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,4 +39,4 @@ DEPENDENCIES
   timecop (~> 0.9)
 
 BUNDLED WITH
-   2.2.22
+   2.3.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,4 +39,4 @@ DEPENDENCIES
   timecop (~> 0.9)
 
 BUNDLED WITH
-   1.17.3
+   2.2.22


### PR DESCRIPTION
Ruby head (3.2) doesn't work with bundler 1, let's migrate to bundler 2

Before:

![Screenshot_2022-01-22_15-59-25](https://user-images.githubusercontent.com/1866809/150643770-ec13b924-d2a2-4f9b-a650-9ab15a8a20c8.png)