### PR TITLE
Better: remove tail command

### DIFF
--- a/lib/core.rb
+++ b/lib/core.rb
@@ -51,8 +51,8 @@ CPU_COLUMN = 8
 
 def get_top_stats(pids)
   pids.each_slice(19).inject({}) do |res, pids19|
-    top_result = `top -b -n 1 -p #{pids19.join(',')} | tail -n #{pids19.length}`
-    top_result.split("\n").map { |row| r = row.split(' '); [r[PID_COLUMN].to_i, get_memory_from_top(r[MEM_COLUMN]), r[CPU_COLUMN].to_f] }
+    top_result = `top -b -n 1 -p #{pids19.join(',')}`
+    top_result.split("\n").last(pids19.length).map { |row| r = row.split(' '); [r[PID_COLUMN].to_i, get_memory_from_top(r[MEM_COLUMN]), r[CPU_COLUMN].to_f] }
       .inject(res) { |hash, row| hash[row[0]] = { mem: row[1], pcpu: row[2] }; hash }
     res
   end

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -6,6 +6,28 @@ require './lib/helpers'
 describe 'Core' do
 
   context 'get_top_stats' do
+    it 'skips top header' do
+      allow(self).to receive(:`) {
+        %Q{top - 16:24:47 up  2:39,  1 user,  load average: 3,30, 3,04, 3,07
+           Tasks:   1 total,   1 running,   0 sleeping,   0 stopped,   0 zombie
+           %Cpu(s): 21,1 us,  2,6 sy,  1,8 ni, 72,2 id,  0,2 wa,  0,0 hi,  2,1 si,  0,0 st
+           KiB Mem : 16259816 total,  2183812 free,  4538464 used,  9537540 buff/cache
+           KiB Swap:  2097148 total,  2097148 free,        0 used. 10639744 avail Mem
+
+           12362 ylecuyer  20   0 1144000  65764   8916 S   0,0  1,8   0:05.18 bundle
+           12366 ylecuyer  20   0 1145032  65732   8936 S   0,0  1,8   0:05.17 bundle
+           12370 ylecuyer  20   0 1143996  65708   8936 S   0,0  1,8   0:05.17 bundle
+           12372 ylecuyer  20   0 1143992  65780   8936 S   0,0  1,8   0:05.16 bundle}
+      }
+
+      expect(get_top_stats([12362, 12366, 12370, 12372])).to eq({
+        12362 => { mem: 64, pcpu: 0.0 },
+        12366 => { mem: 64, pcpu: 0.0 },
+        12370 => { mem: 64, pcpu: 0.0 },
+        12372 => { mem: 64, pcpu: 0.0 }
+      })
+    end
+
     it 'returns mem and cpu' do
       allow(self).to receive(:`) {
         %Q{12362 ylecuyer  20   0 1144000  65764   8916 S   0,0  1,8   0:05.18 bundle


### PR DESCRIPTION
As suggested in #19 the tail command can be replaced with ruby code