### PR TITLE
Show puma and ruby versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,16 @@ $ watch --interval 0.1 --color puma-status path/to/puma.state
 Clustered mode:
 
 ```
-9666 (application/tmp/puma.state) Uptime:  0m43s | Load: 7[███████░░░░░░░░░]16
- └  9706 CPU:   0.0% Mem:   71 MB Uptime:  0m43s | Load: 3[███░]4
- └  9708 CPU:   0.0% Mem:   71 MB Uptime:  0m43s | Load: 4[████]4
- └  9725 CPU:   0.0% Mem:   58 MB Uptime:  0m43s | Load: 0[░░░░]4
- └  9732 CPU:   0.0% Mem:   58 MB Uptime:  0m43s | Load: 0[░░░░]4
+16723 (/tmp/puma.state) Version: 5.6.4/ruby2.5.3p105 | Uptime:  1m50s | Phase: 0 | Load: 2[██░░      ]10 | Req: 936
+ └ 16827 CPU:  93.3% Mem:  140 MB Uptime:  1m50s | Load: 1[█░   ]5 | Req: 469
+ └ 16833 CPU: 106.7% Mem:  145 MB Uptime:  1m50s | Load: 1[█░   ]5 | Req: 467
 ```
 
 Single mode:
 
 ```
-9949 (application/tmp/puma.state) Uptime:  0m 5s | Load: 2[██░░]4
- └  9949 CPU:   0.0% Mem:   75 MB Uptime:  0m 5s | Load: 2[██░░]4
+18847 (/tmp/puma.state) Version: 5.6.4/ruby2.5.3p105 | Uptime:  0m 3s | Load: 1[█░░  ]5 | Req: 672
+ └ 18847 CPU: 120.0% Mem:  143 MB Uptime:  0m 3s | Load: 1[█░░  ]5 | Req: 672
 ```
 
 ## Known issues

--- a/lib/core.rb
+++ b/lib/core.rb
@@ -76,7 +76,9 @@ def hydrate_stats(stats, puma_state, state_file_path)
 end
 
 def format_stats(stats)
-  master_line = "#{stats.pid} (#{stats.state_file_path}) Uptime: #{seconds_to_human(stats.uptime)}"
+  master_line = "#{stats.pid} (#{stats.state_file_path})"
+  master_line += " Version: #{stats.version} |" if stats.version
+  master_line += " Uptime: #{seconds_to_human(stats.uptime)}"
   master_line += " | Phase: #{stats.phase}" if stats.phase
 
   if stats.booting?

--- a/lib/stats.rb
+++ b/lib/stats.rb
@@ -154,4 +154,10 @@ class Stats
   def load
     running_threads/total_threads.to_f*100
   end
+
+  def version
+    return nil unless @stats.key?('versions')
+
+    "#{@stats['versions']['puma']}/#{@stats['versions']['ruby']['engine']}#{@stats['versions']['ruby']['version']}p#{@stats['versions']['ruby']['patchlevel']}"
+  end
 end

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -106,6 +106,16 @@ describe 'Core' do
       Timecop.return
     end
 
+    it 'shows puma and ruby versions if available' do
+      stats = {"started_at"=>"2022-05-30T21:49:20Z", "backlog"=>0, "running"=>2, "pool_capacity"=>5, "max_threads"=>5, "requests_count"=>2, "versions"=>{"puma"=>"5.6.4", "ruby"=>{"engine"=>"ruby", "version"=>"2.5.3", "patchlevel"=>105}}, "pid"=>21725, "state_file_path"=>"../testpuma/tmp/puma.state", "pcpu"=>10, "mem"=>64}
+
+      ClimateControl.modify NO_COLOR: '1' do
+        expect(format_stats(Stats.new(stats))).to eq(
+%Q{21725 (../testpuma/tmp/puma.state) Version: 5.6.4/ruby2.5.3p105 | Uptime: --m--s | Load: 0[░░   ]5 | Req: 2
+ └ 21725 CPU:    10% Mem:   64 MB Uptime: --m--s | Load: 0[░░   ]5 | Req: 2})
+      end
+    end
+
     it 'works in clusted mode' do
       stats = {"started_at"=>"2019-07-14T10:49:24Z", "workers"=>4, "phase"=>0, "booted_workers"=>4, "old_workers"=>0, "worker_status"=>[{"started_at"=>"2019-07-14T10:49:24Z", "pid"=>12362, "index"=>0, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T13:09:00Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>4, "max_threads"=>4}, "mem"=>64, "pcpu"=>0.0}, {"started_at"=>"2019-07-14T10:49:24Z", "pid"=>12366, "index"=>1, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T13:09:00Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>4, "max_threads"=>4}, "mem"=>64, "pcpu"=>0.0}, {"started_at"=>"2019-07-14T10:49:24Z", "pid"=>12370, "index"=>2, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T13:09:00Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>4, "max_threads"=>4}, "mem"=>64, "pcpu"=>0.0}, {"started_at"=>"2019-07-14T10:49:24Z", "pid"=>12372, "index"=>3, "phase"=>0, "booted"=>true, "last_checkin"=>"2019-07-14T13:09:00Z", "last_status"=>{"backlog"=>0, "running"=>4, "pool_capacity"=>4, "max_threads"=>4}, "mem"=>64, "pcpu"=>0.0}], "pid"=>12328, "state_file_path"=>"../testpuma/tmp/puma.state"}
 


### PR DESCRIPTION
Following https://github.com/puma/puma/pull/2875, show puma and ruby versions if present:

```
16723 (/tmp/puma.state) Version: 5.6.4/ruby2.5.3p105 | Uptime:  1m50s | Phase: 0 | Load: 2[██░░      ]10 | Req: 936
 └ 16827 CPU:  93.3% Mem:  140 MB Uptime:  1m50s | Load: 1[█░   ]5 | Req: 469
 └ 16833 CPU: 106.7% Mem:  145 MB Uptime:  1m50s | Load: 1[█░   ]5 | Req: 467
```