### PR TITLE
Breaking: Requires ruby >= 2.5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.3, 2.4, 2.5, 2.6, 2.7, '3.0', 3.1, head]
+        ruby: [2.5, 2.6, 2.7, '3.0', 3.1, head]
 
     steps:
     - name: Checkout repository

--- a/puma-status.gemspec
+++ b/puma-status.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   s.summary = 'Command-line tool for puma to display information about running request/process'
   s.license = "MIT"
   s.homepage = 'https://github.com/ylecuyer/puma-status'
-  s.required_ruby_version = '>=2.3.0'
+  s.required_ruby_version = '>=2.5.0'
 
   s.files = Dir.glob("{bin,lib}/**/*") + %w(LICENSE)
   s.require_paths = ["lib"]


### PR DESCRIPTION
Parallel gem now requires ruby >= 2.5.0 https://github.com/grosser/parallel/commit/d191db712917a13c0beee3bc6b6c0a45b8181521

Also updating here to be compliant