### PR TITLE
warn gets an error in ruby 3.2.1 in some cases

### DIFF
--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -4,7 +4,7 @@ def debug(str)
   puts str if ENV.key?('DEBUG')
 end
 
-def warn(str)
+def warn(str, **_)
   colorize(str, :yellow)
 end
 


### PR DESCRIPTION
using warn(*str, **_) allows a keyword list to be passed to warn and not throw an error. 