### PR TITLE
Minor: Do not overwrite Kernel#warn (#28)

### DIFF
--- a/lib/core.rb
+++ b/lib/core.rb
@@ -82,7 +82,7 @@ def format_stats(stats)
   master_line += " | Phase: #{stats.phase}" if stats.phase
 
   if stats.booting?
-    master_line += " #{warn("booting")}"
+    master_line += " #{yellow("booting")}"
   else
     master_line += " | Load: #{color(75, 50, stats.load, asciiThreadLoad(stats.running_threads, stats.spawned_threads, stats.max_threads))}"
     master_line += " | Req: #{stats.requests_count}" if stats.requests_count
@@ -92,15 +92,15 @@ def format_stats(stats)
     worker_line = " └ #{wstats.pid.to_s.rjust(5, ' ')} CPU: #{color(75, 50, wstats.pcpu, wstats.pcpu.to_s.rjust(5, ' '))}% Mem: #{color(1000, 750, wstats.mem, wstats.mem.to_s.rjust(4, ' '))} MB Uptime: #{seconds_to_human(wstats.uptime)}"
 
     if wstats.booting?
-      worker_line += " #{warn("booting")}"
+      worker_line += " #{yellow("booting")}"
     elsif wstats.killed?
-      worker_line += " #{error("killed")}"
+      worker_line += " #{red("killed")}"
     else
       worker_line += " | Load: #{color(75, 50, wstats.load, asciiThreadLoad(wstats.running_threads, wstats.spawned_threads, wstats.max_threads))}"
-      worker_line += " | Phase: #{error(wstats.phase)}" if wstats.phase != stats.phase
+      worker_line += " | Phase: #{red(wstats.phase)}" if wstats.phase != stats.phase
       worker_line += " | Req: #{wstats.requests_count}" if wstats.requests_count
-      worker_line += " Queue: #{error(wstats.backlog.to_s)}" if wstats.backlog > 0
-      worker_line += " Last checkin: #{error(wstats.last_checkin)}" if wstats.last_checkin >= 10
+      worker_line += " Queue: #{red(wstats.backlog.to_s)}" if wstats.backlog > 0
+      worker_line += " Last checkin: #{red(wstats.last_checkin)}" if wstats.last_checkin >= 10
     end
 
     worker_line

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -4,11 +4,11 @@ def debug(str)
   puts str if ENV.key?('DEBUG')
 end
 
-def warn(str)
+def yellow(str)
   colorize(str, :yellow)
 end
 
-def error(str)
+def red(str)
   colorize(str, :red)
 end
 

--- a/lib/puma-status.rb
+++ b/lib/puma-status.rb
@@ -19,22 +19,22 @@ def run
       format_stats(get_stats(state_file_path))
     rescue Errno::ENOENT => e
       if e.message =~ /#{state_file_path}/
-        errors << "#{warn(state_file_path)} doesn't exists"
+        errors << "#{yellow(state_file_path)} doesn't exists"
       elsif e.message =~ /connect\(2\) for [^\/]/
-        errors << "#{warn("Relative Unix socket")}: the Unix socket of the control app has a relative path. Please, ensure you are running from the same folder has puma."
+        errors << "#{yellow("Relative Unix socket")}: the Unix socket of the control app has a relative path. Please, ensure you are running from the same folder has puma."
       else
-        errors << "#{error(state_file_path)} an unhandled error occured: #{e.inspect}"
+        errors << "#{red(state_file_path)} an unhandled error occured: #{e.inspect}"
       end
       nil
     rescue Errno::EISDIR => e
       if e.message =~ /#{state_file_path}/
-        errors << "#{warn(state_file_path)} isn't a state file"
+        errors << "#{yellow(state_file_path)} isn't a state file"
       else
-        errors << "#{error(state_file_path)} an unhandled error occured: #{e.inspect}"
+        errors << "#{red(state_file_path)} an unhandled error occured: #{e.inspect}"
       end
       nil
     rescue => e
-      errors << "#{error(state_file_path)} an unhandled error occured: #{e.inspect}"
+      errors << "#{red(state_file_path)} an unhandled error occured: #{e.inspect}"
       nil
     end
   end


### PR DESCRIPTION
As explained in https://github.com/ylecuyer/puma-status/pull/27 warn is already defined by Kernel#warn (https://ruby-doc.org/3.2.1/Kernel.html#method-i-warn) so let's avoid overwriting it