### PR TITLE
Replace colorize gem with rainbow gem due to GPL license issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,18 +2,18 @@ PATH
   remote: .
   specs:
     puma-status (1.6)
-      colorize (~> 1.1)
       net_http_unix (~> 0.2)
       parallel (~> 1)
+      rainbow (~> 3.1.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     climate_control (0.2.0)
-    colorize (1.1.0)
     diff-lcs (1.5.0)
     net_http_unix (0.2.2)
     parallel (1.24.0)
+    rainbow (3.1.1)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -1,20 +1,20 @@
-require 'colorize'
+require 'rainbow'
 
 def debug(str)
   puts str if ENV.key?('DEBUG')
 end
 
 def yellow(str)
-  colorize(str, :yellow)
+  rainbow(str, :yellow)
 end
 
 def red(str)
-  colorize(str, :red)
+  rainbow(str, :red)
 end
 
-def colorize(str, color_name)
+def rainbow(str, color_name)
   return str if ENV.key?('NO_COLOR')
-  str.to_s.colorize(color_name)
+  Rainbow(str.to_s).send(color_name)
 end
 
 def color(critical, warn, value, str = nil)
@@ -26,7 +26,7 @@ def color(critical, warn, value, str = nil)
           else
             :green
           end
-  colorize(str, color_level)
+  rainbow(str, color_level)
 end
 
 def asciiThreadLoad(running, spawned, total)

--- a/puma-status.gemspec
+++ b/puma-status.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.executables = ['puma-status']
 
-  s.add_runtime_dependency "colorize", '~> 1.1'
+  s.add_runtime_dependency "rainbow", '~> 3.1.1'
   s.add_runtime_dependency "net_http_unix", '~> 0.2'
   s.add_runtime_dependency "parallel", '~> 1'
 


### PR DESCRIPTION
Replaced colorize gem with rainbow gem due to GPL license issue
- Removed colorize gem
- Added rainbow gem (version 3.1.1)
- Updated `lib/helpers.rb` file to replace colorize method with rainbow method
